### PR TITLE
[update] 自作例外クラスの場合のインナーエクセプションについて

### DIFF
--- a/CsharpLog4net/App.config
+++ b/CsharpLog4net/App.config
@@ -43,7 +43,7 @@
 			<!--何世代ログファイルを作成するか。今回は3世代 + 現在のログファイル = 合計4つのファイルで管理する-->
 			<param name="maxSizeRollBackups" value="3"/>
 			<!--出力ログのサイズを指定（確認用で小さめのサイズに指定。本来は10MB～50MBくらいをを目安に）-->
-			<param name="maximumFileSize" value="5KB"/>
+			<param name="maximumFileSize" value="10KB"/>
 			<!--固定ファイル名にしない設定-->
 			<param name="staticLogFileName" value="false"/>
 			

--- a/CsharpLog4net/App.xaml
+++ b/CsharpLog4net/App.xaml
@@ -2,7 +2,9 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:CsharpLog4net"
-             StartupUri="MainWindow.xaml">
+             StartupUri="MainWindow.xaml"
+             DispatcherUnhandledException="Application_DispatcherUnhandledException"
+             >
     <Application.Resources>
          
     </Application.Resources>

--- a/CsharpLog4net/App.xaml.cs
+++ b/CsharpLog4net/App.xaml.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using log4net;
+using System.Reflection;
 using System.Windows;
+using System.Windows.Threading;
 
 namespace CsharpLog4net
 {
@@ -13,5 +10,21 @@ namespace CsharpLog4net
     /// </summary>
     public partial class App : Application
     {
+
+        private static readonly ILog _logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        public App()
+        {
+
+        }
+
+        private void Application_DispatcherUnhandledException(object sender,
+            DispatcherUnhandledExceptionEventArgs e)
+        {
+            _logger.Error(e.Exception.Message, e.Exception);
+            MessageBox.Show(e.Exception.Message);
+
+            // ハンドルされない例外を処理済みにするためにtrueを指定
+            e.Handled = true;
+        }
     }
 }

--- a/CsharpLog4net/MainWindow.xaml
+++ b/CsharpLog4net/MainWindow.xaml
@@ -8,7 +8,8 @@
         Title="MainWindow" Height="450" Width="450
         ">
     <Grid>
-        <Button Content="Button" HorizontalAlignment="Left" Margin="59,49,0,0" VerticalAlignment="Top" Height="59" Width="126" Click="Button_Click1"/>
-        <Button Content="Button" HorizontalAlignment="Left" Margin="59,113,0,0" VerticalAlignment="Top" Height="59" Width="126" Click="Button_Click2"/>
+        <Button Content="Button" HorizontalAlignment="Left" Margin="60,50,0,0" VerticalAlignment="Top" Height="59" Width="126" Click="Button_Click1"/>
+        <Button Content="Button" HorizontalAlignment="Left" Margin="60,120,0,0" VerticalAlignment="Top" Height="59" Width="126" Click="Button_Click2"/>
+        <Button Content="Button" HorizontalAlignment="Left" Margin="60,190,0,0" VerticalAlignment="Top" Height="59" Width="126" Click="Button_Click3"/>
     </Grid>
 </Window>

--- a/CsharpLog4net/MainWindow.xaml.cs
+++ b/CsharpLog4net/MainWindow.xaml.cs
@@ -18,7 +18,6 @@ namespace CsharpLog4net
         public MainWindow()
         {
             InitializeComponent();
-       
         }
 
         private void Button_Click1(object sender, RoutedEventArgs e)
@@ -50,6 +49,50 @@ namespace CsharpLog4net
             {
                 _logger.Error("例外が発生：", ex);
             }
+        }
+
+        private void Button_Click3(object sender, RoutedEventArgs e)
+        {
+            //try
+            //{
+            //    GetData();
+            //}
+            //catch (Exception ex)
+            //{
+            //    _logger.Error("エラー！！", ex);
+            //}
+
+            // どこにもキャッチされていない例外はApp.xamlに作成した
+            // Application_DispatcherUnhandledException でキャッチされる
+            GetData();
+        }
+
+        private void GetData()
+        {
+            try
+            {
+                var lists = new List<int>();
+                var csv = lists[0];
+            }
+            catch (Exception ex)
+            {
+                // Exceptionの情報は無くしたくないが、出力されるメッセージはオリジナルのものにしたい
+                throw new CsvReadException(ex);
+            }
+        }
+    }
+
+    // 自作の例外
+    public sealed class CsvReadException : Exception
+    {
+        // CSVの読み込みでindexの境界外でArgumentOutOfRangeExceptionだったけれども
+        // CsvExceptionとしたい場合
+        // 引数にオリジナルのExceptionを指定していると、元情報のExceptionを保持しながらオリジナルのメッセージを出力する事ができる
+        // つまり、オリジナルの例外を出しつつ、その情報が何でどの行のコードなのか詳細な情報（innerException）も出せる
+        public CsvReadException(Exception exception)
+            :base("CSVの読み込みに失敗しました", exception)
+        {
+
         }
     }
 }


### PR DESCRIPTION
# WPFで例外を集約させる記述は、Windowsフォームの書き方とは違うので注意
- [https://blog.jhashimoto.net/entry/20101212/1292138123](https://blog.jhashimoto.net/entry/20101212/1292138123)
- [https://takap-tech.com/entry/2018/05/08/020351](https://takap-tech.com/entry/2018/05/08/020351)